### PR TITLE
docs: rebrand messaging from 'fix bugs' to 'enhance behavior'

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,8 @@ This file helps Claude Code understand the project structure and development wor
 
 Claude Code Plus is an installer that enhances Claude Code CLI. It addresses two main issues:
 
-1. **Piped commands not auto-approved** ([#13340](https://github.com/anthropics/claude-code/issues/13340)) - Fixed via a PreToolUse hook
-2. **Custom shell not respected** ([#7490](https://github.com/anthropics/claude-code/issues/7490)) - Fixed via settings.json env config + shell alias workaround
+1. **Piped commands not auto-approved** ([#13340](https://github.com/anthropics/claude-code/issues/13340)) - Addressed via a PreToolUse hook
+2. **Custom shell not respected** ([#7490](https://github.com/anthropics/claude-code/issues/7490)) - Addressed via settings.json env config + shell alias workaround
 
 ## Project Structure
 
@@ -137,7 +137,7 @@ Then rebuild with `npm run build`.
 3. **Non-interactive mode**: `-y` flag for scripting/automation
 4. **Cross-platform bash detection**: Finds modern bash dynamically (Homebrew paths on macOS, /bin/bash on Linux)
 5. **Auto-detect chezmoi**: Automatically detects if `~/.claude` is managed by chezmoi and adjusts paths/prefixes accordingly
-6. **Shell alias workaround**: Adds `claude` function to shell configs that sets `SHELL` env var (workaround until upstream bug is fixed)
+6. **Shell alias workaround**: Adds `claude` function to shell configs that sets `SHELL` env var (workaround until this is addressed upstream)
 
 ### CLI Flags
 
@@ -163,7 +163,7 @@ The installer auto-detects chezmoi:
 
 ### Shell Alias Workaround (`src/shell-alias.ts`)
 
-Until Claude Code fixes issue #7490, we add a shell function/alias:
+Until Claude Code addresses issue #7490, we add a shell function/alias:
 - Bash/Zsh: `claude() { SHELL=/path/to/bash command claude "$@"; }`
 - Fish: `function claude; SHELL=/path/to/bash command claude $argv; end`
 - Added to all existing shell config files (.bashrc, .bash_profile, .zshrc, config.fish)
@@ -253,5 +253,5 @@ sed -n '45,95p' src/old-file.ts > src/new-file.ts
 
 ## Related Issues
 
-- [#13340](https://github.com/anthropics/claude-code/issues/13340) - Piped commands permission bug
+- [#13340](https://github.com/anthropics/claude-code/issues/13340) - Piped commands permission limitation
 - [#7490](https://github.com/anthropics/claude-code/issues/7490) - Custom shell not respected

--- a/internal-tracking/TODOS.md
+++ b/internal-tracking/TODOS.md
@@ -16,7 +16,7 @@
 - [ ] [12. Dotfiles manager support for shell config modifications](#12-dotfiles-manager-support-for-shell-config-modifications)
 - [ ] [13. Redesign installer flow with customization options](#13-redesign-installer-flow-with-customization-options)
 - [ ] [14. Document and showcase hook capabilities](#14-document-and-showcase-hook-capabilities)
-- [ ] [15. Rebrand from "fix bugs" to "enhance behavior"](#15-rebrand-from-fix-bugs-to-enhance-behavior)
+- [x] [15. Rebrand from "fix bugs" to "enhance behavior"](#15-rebrand-from-fix-bugs-to-enhance-behavior)
 - [x] [16. Remove --hook-prefix flag after dotfiles manager support](#16-remove---hook-prefix-flag-after-dotfiles-manager-support)
 - [x] [17. Default shell to bash instead of $SHELL](#17-default-shell-to-bash-instead-of-shell)
 - [x] [18. Use relative hook path in settings.json](#18-use-relative-hook-path-in-settingsjson) - Uses `$HOME` which Claude expands at runtime


### PR DESCRIPTION
## Summary

- Updates terminology in CLAUDE.md to use more positive framing
- Changes "Fixed via" → "Addressed via" for issue descriptions
- Changes "upstream bug is fixed" → "this is addressed upstream"
- Changes "permission bug" → "permission limitation"
- Marks TODO #15 as complete

This aligns CLAUDE.md with README.md, which already uses the "Enhancements" and "The limitation" / "What we add" pattern.

## Test plan

- [x] All 94 tests pass
- [x] No code changes, documentation only