### PR TITLE
Add GitHub Actions for CI/CD

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+changelog:
+  categories:
+    - title: "⚠️ Breaking Changes"
+      labels: [breaking-change]
+    - title: "🔒 Security"
+      labels: [security]
+    - title: "🚀 Features"
+      labels: [enhancement, feature]
+    - title: "🐛 Bug Fixes"
+      labels: [bug]
+    - title: "⚡ Performance"
+      labels: [performance]
+    - title: "♻️ Refactoring"
+      labels: [refactor]
+    - title: "📚 Documentation"
+      labels: [documentation]
+    - title: "🔧 Maintenance"
+      labels: [chore, maintenance, dependencies, ci]
+    - title: "Other Changes"
+      labels: ["*"]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linter
+        run: npm run lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 1.2.0)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18.x'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Run linter
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Update version
+        run: npm version ${{ inputs.version }} --no-git-tag-version
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ inputs.version }}
+          name: v${{ inputs.version }}
+          generate_release_notes: true
+          make_latest: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -9,6 +9,7 @@ export const DEFAULT_PERMISSIONS: string[] = [
   'Bash(R --version:*)',
   'Bash(Rscript --version:*)',
   'Bash(actionlint --version:*)',
+  'Bash(actionlint:*)',
   'Bash(age --version:*)',
   'Bash(ansible --version:*)',
   'Bash(ansible-galaxy list:*)',


### PR DESCRIPTION
## Summary

Adds GitHub Actions workflows for automated CI/CD:

- **lint.yml** - Runs ESLint on push/PR to main (Node 18.x)
- **test.yml** - Runs Jest tests on push/PR to main (Node 18.x)
- **publish.yml** - Manual workflow to publish to npm and create GitHub release

Lint and test workflows run in parallel for faster feedback.

### Publish workflow

Triggered manually via GitHub Actions UI with a version input (e.g., `1.2.0`). It:
1. Runs tests and lint
2. Builds the project
3. Updates package.json version
4. Publishes to npm with provenance
5. Creates a GitHub Release with auto-generated release notes

**Required setup:** Add `NPM_TOKEN` secret to the repo.

### Release notes

Added `.github/release.yml` to categorize release notes by PR labels:
- ⚠️ Breaking Changes
- 🔒 Security
- 🚀 Features
- 🐛 Bug Fixes
- ⚡ Performance
- ♻️ Refactoring
- 📚 Documentation
- 🔧 Maintenance

Also created the following labels on the repo: `feature`, `performance`, `security`, `breaking-change`, `refactor`, `ci`, `chore`, `maintenance`, `dependencies`.

### Other changes

- Added `Bash(actionlint:*)` to permissions.ts for workflow validation

## Test plan

- [ ] Verify lint workflow runs on PR
- [ ] Verify test workflow runs on PR
- [ ] After merge, test publish workflow manually (dry run first)