### PR TITLE
ci: use OIDC trusted publishing, remove NPM_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,8 +41,6 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary

- Remove `NPM_TOKEN` secret from publish workflow
- Use npm's Trusted Publishing with OIDC instead

## Why

npm now supports Trusted Publishing via OIDC, which is more secure than long-lived tokens:
- No secrets to rotate or leak
- Each publish is authenticated via short-lived, workflow-specific credentials
- Provenance attestation is enabled by default

## Required setup on npmjs.com

After merging, configure the trusted publisher at https://www.npmjs.com/package/claude-code-plus/access:

- **Repository owner:** `AbdelrahmanHafez`
- **Repository:** `claude-code-plus`
- **Workflow filename:** `publish.yml`
- **Environment:** (leave empty)

## Test plan

- [ ] Configure trusted publisher on npmjs.com
- [ ] Trigger a test publish via workflow_dispatch