### PR TITLE
ci: add bats tests for hook scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,8 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  unit-tests:
+    name: Unit Tests (Jest)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,3 +24,22 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+  hook-tests:
+    name: Hook Tests (Bats)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq shfmt
+
+      - name: Install bats
+        run: |
+          git clone https://github.com/bats-core/bats-core.git /tmp/bats-core
+          sudo /tmp/bats-core/install.sh /usr/local
+
+      - name: Run hook tests
+        run: bats test/


### PR DESCRIPTION
## Summary
- Add a new `hook-tests` job to run bats tests in CI
- Install jq and shfmt dependencies required by the hook script
- Install bats-core for running the test suite
- Renames existing job to `unit-tests` for clarity

## Test plan
- [ ] Verify bats tests pass in CI