### PR TITLE
ci: use Node 24 for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '24.x'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
## Summary
- Upgrade Node.js from 18.x to 24.x in the publish workflow
- Node 24 includes npm 11.6.x which supports OIDC trusted publishing (requires npm >= 11.5.1)

## Context
The previous publish workflow failed because OIDC trusted publishing requires npm 11.5.1+, but Node 18.x ships with npm 9.x.

Error from failed run:
```
npm notice Access token expired or revoked. Please try logging in again.
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/claude-code-plus - Not found
```

## Test plan
- [ ] Verify publish workflow succeeds with OIDC authentication