### PR TITLE
ci: reuse test workflow in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,8 +9,13 @@ on:
         type: string
 
 jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+
   publish:
+    needs: test
     runs-on: ubuntu-latest
+    environment: release # Must match npm trusted publisher config
     permissions:
       contents: write
       id-token: write
@@ -26,9 +31,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Run tests
-        run: npm test
 
       - name: Run linter
         run: npm run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call: # Allow other workflows to call this one
 
 jobs:
   unit-tests:


### PR DESCRIPTION
## Summary
- Add `workflow_call` trigger to test.yml so it can be reused
- Update publish.yml to call the test workflow instead of duplicating test logic
- Also adds back `environment: release` for npm OIDC trusted publishing

## Changes
- test.yml: Add `workflow_call` trigger
- publish.yml: Replace duplicated test steps with `uses: ./.github/workflows/test.yml`

## Test plan
- [ ] Verify test workflow still runs on push/PR
- [ ] Verify publish workflow calls test workflow before publishing