### PR TITLE
fix: add repository URL for npm provenance and use shallow clones in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -30,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
       - name: Install dependencies
         run: |
@@ -38,7 +42,7 @@ jobs:
 
       - name: Install bats
         run: |
-          git clone https://github.com/bats-core/bats-core.git /tmp/bats-core
+          git clone --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats-core
           sudo /tmp/bats-core/install.sh /usr/local
 
       - name: Run hook tests

--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
   ],
   "author": "",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AbdelrahmanHafez/claude-code-plus"
+  },
   "devDependencies": {
     "@eslint/js": "^9.0.0",
     "@stylistic/eslint-plugin": "^2.0.0",


### PR DESCRIPTION
## Summary
- Add `repository.url` to package.json (required for npm provenance verification)
- Use `fetch-depth: 1` for all `actions/checkout` steps to speed up CI
- Use `--depth 1` for bats-core clone

## Problem
The publish workflow was failing with:
```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/claude-code-plus - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/AbdelrahmanHafez/claude-code-plus" from provenance
```

## Test plan
- [ ] Verify lint workflow passes
- [ ] Verify test workflow passes
- [ ] Manually trigger publish workflow to confirm provenance verification succeeds