### PR TITLE
ci: upgrade actions/checkout to v6 and remove redundant fetch-depth

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,9 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
+        uses: actions/checkout@v6
 
       - name: Run Claude Code Review
         id: claude-review

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,9 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
+        uses: actions/checkout@v6
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,9 +20,7 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,7 @@ jobs:
     name: Unit Tests (Jest)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -32,9 +30,7 @@ jobs:
     name: Hook Tests (Bats)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary

- Upgraded `actions/checkout` from v4 to v6 (latest version) across all workflow files
- Removed explicit `fetch-depth: 1` configuration since it's the default behavior

## Changes

Updated the following workflows:
- `.github/workflows/test.yml` (2 instances)
- `.github/workflows/lint.yml`
- `.github/workflows/publish.yml`
- `.github/workflows/claude.yml`
- `.github/workflows/claude-code-review.yml`

## Why

- `fetch-depth: 1` is already the default for `actions/checkout`, making the explicit configuration redundant
- Using the latest v6 ensures we have the latest features and bug fixes
- Cleaner workflow configuration with less boilerplate

## Testing

All existing tests should continue to pass as this only changes the checkout action version and removes redundant configuration.