### PR TITLE
chore: add dependabot for monthly dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "ci"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

- Adds Dependabot configuration for automated dependency updates
- Configures monthly checks for both npm packages and GitHub Actions
- Uses conventional commit prefixes (`chore(deps)`) for PR titles

## Configuration Details

- **npm dependencies**: Monthly updates, limit 10 open PRs
- **GitHub Actions**: Monthly updates, limit 5 open PRs
- Labels auto-applied: `dependencies` (both), `ci` (actions only)